### PR TITLE
fix: adds https support for getToken

### DIFF
--- a/console/src/middleware.ts
+++ b/console/src/middleware.ts
@@ -4,7 +4,12 @@ import { getRoles } from "./lib/utils";
 import { auth } from "./auth";
 
 export default auth(async (req) => {
-  const token = await getToken({ req, secret: process.env.AUTH_SECRET });
+  const secureCookie = req.nextUrl.protocol === "https:";
+  const token = await getToken({
+    req,
+    secret: process.env.AUTH_SECRET,
+    secureCookie,
+  });
   const baseUrl = req.nextUrl.origin;
   const currentPath = req.nextUrl.pathname;
   if (!token || token.expiresAt < Math.floor(Date.now() / 1000)) {


### PR DESCRIPTION
Authjs automatically prepends `__Secure-` to the cookie name when it detects an https connection. The `getToken` method cannot automatically figure out if the connection is http or https, it needs to be specified with the `secureCookie` method parameter.

Context on why Authjs prepends `__Secure-`:

<img width="760" height="342" alt="image" src="https://github.com/user-attachments/assets/8653e81c-55c9-4752-ab3f-33bf03851b6e" />
 