### PR TITLE
feat: receives LHUT_OAUTH_CALLBACK_URL to specify the base url when it cannot be inferred

### DIFF
--- a/console/entrypoint.sh
+++ b/console/entrypoint.sh
@@ -28,4 +28,8 @@ export AUTH_KEYCLOAK_ID=${LHUT_OAUTH_CLIENT_ID}
 export AUTH_KEYCLOAK_SECRET=${LHUT_OAUTH_CLIENT_SECRET}
 export AUTH_KEYCLOAK_ISSUER=${LHUT_OAUTH_ISSUER_URI}
 
+if [ -n "${LHUT_OAUTH_CALLBACK_URL}" ]; then
+    export AUTH_URL=${LHUT_OAUTH_CALLBACK_URL} # https://authjs.dev/getting-started/deployment#auth_url
+fi
+
 /entrypoint.sh


### PR DESCRIPTION
Authjs v5 infers the base url to redirect to based on the `X-Forwarded-Host` header, if such header is not present such as in local development, then it redirects to localhost:3000 by default. Adding the `LHUT_OAUTH_CALLBACK_URL` allow us to specify a base url when it cannot be inferred properly