### PR TITLE
feat: introduces LHUT_API_CA_CERT to add support for a backend custom CA

### DIFF
--- a/console/entrypoint.sh
+++ b/console/entrypoint.sh
@@ -32,4 +32,8 @@ if [ -n "${LHUT_OAUTH_CALLBACK_URL}" ]; then
     export AUTH_URL=${LHUT_OAUTH_CALLBACK_URL} # https://authjs.dev/getting-started/deployment#auth_url
 fi
 
+if [ -n "${LHUT_API_CA_CERT}" ]; then
+    export NODE_EXTRA_CA_CERTS=${LHUT_API_CA_CERT}
+fi
+
 /entrypoint.sh


### PR DESCRIPTION
The `fetch` being used to make calls to the backend is the "standard" browser fetch API. According to my research, this `fetch` doesn't support providing a custom CA to validate certificates. So, in order to be able to support a custom CA we need to add it to the NodeJS runtime by setting the certificate path in the environment variable `NODE_EXTRA_CA_CERTS` ([more info here](https://nodejs.org/api/cli.html#node_extra_ca_certsfile))